### PR TITLE
Add default config options to bom.ini

### DIFF
--- a/bom.ini
+++ b/bom.ini
@@ -24,6 +24,10 @@ make_backup = %O.tmp
 number_boards = 1
 ; Default PCB variant if none given on CLI with -r
 board_variant = default
+; Specify output file name format, %O is the defined output name, %v is the version, %V is the variant name which will be ammended according to 'variant_file_name_format'.
+output_file_name = %O_bom_%v%V
+; Specify the variant file name format, this is a unique field as the variant is not always used/specified. When it is unused you will want to strip all of this.
+variant_file_name_format = _(%V)
 
 [IGNORE_COLUMNS]
 ; Any column heading that appears here will be excluded from the Generated BoM


### PR DESCRIPTION
KiBoM failes with bom.ini because two default options are missing in the bom.ini file.